### PR TITLE
Add support a non-random parameter zero-inflation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: coala
-Version: 0.1.1.9000
-Date: 2015-07-31
+Version: 0.1.1.9001
+Date: 2015-08-24
 License: MIT + file LICENSE
 Title: A Framework for Coalescent Simulation
 Authors@R: c(

--- a/NEWS
+++ b/NEWS
@@ -1,16 +1,25 @@
+coala 0.1.1.9001
+----------------
+
+* Adds optional support for parameter zero inflation for a deterministic
+  fraction of loci instead of a random number. Can be used by setting
+  `random = FALSE` in `par_zero_inflation` (#97).
+
+
+
 coala 0.1.1.9000
 ----------------
 
-* Add MCMF summary statistic (#94).
+* Adds the MCMF summary statistic (#94).
 
 
 
 coala 0.1.1
 -----------
 
-* Fix a memory corruption that occured only in tests (#90).
-* Update `README.md`.
-* Correct various typos.
+* Fixes a memory corruption that occured only in tests (#90).
+* Updates `README.md`.
+* Corrects various typos.
 
 
 

--- a/R/par_zero_inflation.R
+++ b/R/par_zero_inflation.R
@@ -7,6 +7,18 @@ zero_inflation_par_class <- R6Class("zero_inflation_par",
 #' @importFrom stats rbinom
 zero_inflate <- function(x, prob) ifelse(rbinom(1, 1, prob), 0, x)
 
+
+#' @importFrom R6 R6Class
+zero_frac_par_class <- R6Class("zero_inflation_par",
+  inherit = variation_par_class,
+  private = list(func = "zero_frac")
+)
+
+create_zero_frac_func <- function(locus_id, locus_number) {
+  function(x, frac) ifelse(locus_id <= frac * locus_number, 0, x)
+}
+
+
 #' Zero inflation for Parameters
 #'
 #' This adds a zero inflation to the distribution of a parameter for the
@@ -19,8 +31,13 @@ zero_inflate <- function(x, prob) ifelse(rbinom(1, 1, prob), 0, x)
 #'
 #' @param par A parameter whose value will be set variable.
 #' @param prob The probability that the parameters value will be set to `0`
-#'   for each locus.
+#'   for each locus if \code{random} is \code{TRUE}. Otherwise, it's the
+#'   fixed fraction of loci which will have a parameter value of `0`.
+#' @param random Whether the number of loci which are simulated with a value of
+#'   `0` should be random (\code{TRUE}) or a fixed fraction (\code{FALSE}). See
+#'   \code{prob} for details.
 #' @export
-par_zero_inflation <- function(par, prob) {
-  zero_inflation_par_class$new(par, prob)
+par_zero_inflation <- function(par, prob, random = TRUE) {
+  if (random) zero_inflation_par_class$new(par, prob)
+  else zero_frac_par_class$new(par, prob)
 }

--- a/R/parameter.R
+++ b/R/parameter.R
@@ -180,6 +180,9 @@ create_par_env <- function(model, parameters, ..., for_cmd = FALSE) {
     par_env[[names(additional_pars)[i]]] <- additional_pars[[i]]
   }
 
+  par_env[["zero_frac"]] <- create_zero_frac_func(additional_pars$locus_id,
+                                                  additional_pars$locus_number)
+
   par_env
 }
 

--- a/R/simulator_class.R
+++ b/R/simulator_class.R
@@ -35,17 +35,22 @@ get_simulator <- function(name) {
 
 fill_cmd_template <- function(template, model, parameters,
                               locus_group, eval_pars = TRUE) {
+
   locus_length <- get_locus_length(model, group = locus_group)
+  total_locus_number <- get_locus_number(model, locus_group, TRUE)
 
   if (has_variation(model)) {
-    locus_number <- rep(1, get_locus_number(model, locus_group, TRUE))
+    locus_number <- rep(1, total_locus_number)
   } else {
-    locus_number <- get_locus_number(model, locus_group, TRUE)
+    locus_number <- total_locus_number
   }
+  locus_id <- seq(along = locus_number)
 
-  args <- sapply(locus_number, function(ln) {
+  args <- sapply(locus_id, function(l_id) {
     tmp_env <- create_par_env(model, parameters,
                               locus_length = locus_length,
+                              locus_id = l_id,
+                              locus_number = total_locus_number,
                               for_cmd = !eval_pars)
 
     paste(eval(parse(text = template), envir = tmp_env), collapse = " ")

--- a/man/par_zero_inflation.Rd
+++ b/man/par_zero_inflation.Rd
@@ -4,13 +4,18 @@
 \alias{par_zero_inflation}
 \title{Zero inflation for Parameters}
 \usage{
-par_zero_inflation(par, prob)
+par_zero_inflation(par, prob, random = TRUE)
 }
 \arguments{
 \item{par}{A parameter whose value will be set variable.}
 
 \item{prob}{The probability that the parameters value will be set to `0`
-for each locus.}
+for each locus if \code{random} is \code{TRUE}. Otherwise, it's the
+fixed fraction of loci which will have a parameter value of `0`.}
+
+\item{random}{Whether the number of loci which are simulated with a value of
+`0` should be random (\code{TRUE}) or a fixed fraction (\code{FALSE}). See
+\code{prob} for details.}
 }
 \description{
 This adds a zero inflation to the distribution of a parameter for the

--- a/tests/testthat/test-parameter-zero-inflation.R
+++ b/tests/testthat/test-parameter-zero-inflation.R
@@ -1,6 +1,6 @@
 context("Parameter Zero Inflation")
 
-test_that("Parameters with variation can be initialized", {
+test_that("parameters with zero inflation can be initialized", {
   set.seed(114422)
   par <- par_zero_inflation(par_const(5), 0.20)
   expect_true(is.par(par))
@@ -24,6 +24,27 @@ test_that("Parameters with variation can be initialized", {
   par <- par_zero_inflation(5, "a")
   a <- .1
   expect_that(par$eval(), is_a("numeric"))
+})
+
+
+test_that("non-random zero inflation works", {
+  model <- coal_model(5, 100) +
+    feat_mutation(par_zero_inflation(5, 0.211, FALSE))
+  expect_true(has_variation(model))
+  tmplt <- scrm_create_cmd_template(model)
+  cmd_tmplt <- fill_cmd_template(tmplt, model, NULL, locus_group = 1)
+  expect_equivalent(cmd_tmplt, data.frame(locus_number = c(21, 79),
+                                          command = c("-t 0 ", "-t 5 "),
+                                          stringsAsFactors = FALSE))
+
+  model <- coal_model(5, 100) +
+    feat_mutation(par_zero_inflation(5, 0.4, FALSE))
+  expect_true(has_variation(model))
+  tmplt <- scrm_create_cmd_template(model)
+  cmd_tmplt <- fill_cmd_template(tmplt, model, NULL, locus_group = 1)
+  expect_equivalent(cmd_tmplt, data.frame(locus_number = c(40, 60),
+                                          command = c("-t 0 ", "-t 5 "),
+                                          stringsAsFactors = FALSE))
 })
 
 


### PR DESCRIPTION
Adds optional support for parameter zero inflation for a deterministic fraction of loci instead of a random number. Can be used by setting `random = FALSE` in `par_zero_inflation`.