### PR TITLE
fix iHS calc with position and max_snps

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: coala
-Version: 0.1.1.9001
+Version: 0.1.1.9002
 Date: 2015-08-24
 License: MIT + file LICENSE
 Title: A Framework for Coalescent Simulation

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,12 @@
+coala 0.1.1.9002
+----------------
+
+* Fixes buggy iHS calculation when `max_snps` and `position` was used
+  simultainously. The argument `max_snps` is now ignored if a position
+  is given (#98).
+
+
+
 coala 0.1.1.9001
 ----------------
 

--- a/R/sumstat_ihh.R
+++ b/R/sumstat_ihh.R
@@ -45,11 +45,11 @@ stat_ihh_class <- R6Class("stat_ihh", inherit = sumstat_class,
           assert_that(length(snps) == 1)
           ihh <- matrix(0, 1, 3)
           colnames(ihh) <- c("IHHa", "IHHd", "IES")
-          ihh[1, 1:2] <- calc_ehh(rehh_data, mrk = snps, plotehh = FALSE)$ihh #nolint
-          ihh[1, 3] <- calc_ehhs(rehh_data, mrk = snps, plotehhs = FALSE)$ies #nolint
+          ihh[1, 1:2] <- calc_ehh(rehh_data, mrk = snps, plotehh = FALSE)$ihh
+          ihh[1, 3] <- calc_ehhs(rehh_data, mrk = snps, plotehhs = FALSE)$ies
           return(ihh)
         }
-        rehh::scan_hh(rehh_data)[ , -(1:3), drop = FALSE] #nolint
+        rehh::scan_hh(rehh_data)[ , -(1:3), drop = FALSE]
       })
     },
     create_rehh_data = function(seg_sites, pos, ind) {
@@ -66,7 +66,9 @@ stat_ihh_class <- R6Class("stat_ihh", inherit = sumstat_class,
     },
     create_snp_mask = function(seg_sites) {
       n_snps <- ncol(seg_sites)
-      if (n_snps < private$max_snps) return(rep(TRUE, n_snps))
+      if (n_snps < private$max_snps || !is.na(private$position)) {
+        return(rep(TRUE, n_snps))
+      }
       sample.int(n_snps, private$max_snps, replace = FALSE)
     }
   )
@@ -94,8 +96,9 @@ stat_ihh_class <- R6Class("stat_ihh", inherit = sumstat_class,
 #'   are used.
 #' @param max_snps The maximal number of SNPs per locus that are used for the
 #'   calculation. If a locus has more SNPs than this number, only a
-#'   evenly distributed subset of this size will be used for calculating iHS
-#'   to increase performance. Set to \code{Inf} to use all SNPs.
+#'   random subset will be used for calculating iHS to increase performance.
+#'   Set to \code{Inf} to use all SNPs. When \code{position} is given,
+#'   this argument is ignored and all SNPs are used.
 #' @return When added to a model, the statistic returns a matrix for each locus.
 #'   The columns of the values state the values for integrated EHH for the
 #'   ancestral allele (IHHa), integrated EHH for the derived allele (IHHd) and

--- a/man/sumstat_ihh.Rd
+++ b/man/sumstat_ihh.Rd
@@ -23,8 +23,9 @@ are used.}
 
 \item{max_snps}{The maximal number of SNPs per locus that are used for the
 calculation. If a locus has more SNPs than this number, only a
-evenly distributed subset of this size will be used for calculating iHS
-to increase performance. Set to \code{Inf} to use all SNPs.}
+random subset will be used for calculating iHS to increase performance.
+Set to \code{Inf} to use all SNPs. When \code{position} is given,
+this argument is ignored and all SNPs are used.}
 }
 \value{
 When added to a model, the statistic returns a matrix for each locus.

--- a/man/sumstat_nSL.Rd
+++ b/man/sumstat_nSL.Rd
@@ -23,8 +23,9 @@ are used.}
 
 \item{max_snps}{The maximal number of SNPs per locus that are used for the
 calculation. If a locus has more SNPs than this number, only a
-evenly distributed subset of this size will be used for calculating iHS
-to increase performance. Set to \code{Inf} to use all SNPs.}
+random subset will be used for calculating iHS to increase performance.
+Set to \code{Inf} to use all SNPs. When \code{position} is given,
+this argument is ignored and all SNPs are used.}
 }
 \value{
 When added to a model, the statistic returns a vector for each locus,

--- a/tests/testthat/test-sumstat-iHH.R
+++ b/tests/testthat/test-sumstat-iHH.R
@@ -41,6 +41,15 @@ test_that("selection of snps works", {
 })
 
 
+test_that("all snps are used if a position is given", {
+  stat_ihh <- sumstat_ihh(population = 1, max_snps = 2, position = .5)
+  rehh_data <- stat_ihh$create_rehh_data(seg_sites, pos, 1:4)
+  expect_equal(dim(rehh_data@haplo), c(4, 5))
+  expect_equal(rehh_data@nsnp, 5)
+  expect_equal(rehh_data@nhap, 4)
+})
+
+
 test_that("calculation of ihh works", {
   skip_if_not_installed("rehh")
   stat_ihh <- sumstat_ihh()


### PR DESCRIPTION
* Fixes buggy iHS calculation when `max_snps` and `position` was used
  simultaneously. The argument `max_snps` is now ignored if a position
  is given (#98).