### PR TITLE
store seq-gen results in memory

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: coala
-Version: 0.1.1.9002
-Date: 2015-08-24
+Version: 0.1.1.9003
+Date: 2015-09-02
 License: MIT + file LICENSE
 Title: A Framework for Coalescent Simulation
 Authors@R: c(

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,11 @@
+coala 0.1.1.9003
+----------------
+
+* Now writes seq-gen output into memory and not in files before it is parsed.
+* Minor change: `get_outgroup` now returns `NA` if the model has no outgroup
+  rather than throwing an error.
+
+
 coala 0.1.1.9002
 ----------------
 

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -9,8 +9,8 @@ parse_ms_output <- function(file_names, sample_size, loci_number) {
     .Call('coala_parse_ms_output', PACKAGE = 'coala', file_names, sample_size, loci_number)
 }
 
-parse_sg_output <- function(file_names, sample_size, sequence_length, loci_number, outgroup_size = 1L, calc_seg_sites = TRUE) {
-    .Call('coala_parse_sg_output', PACKAGE = 'coala', file_names, sample_size, sequence_length, loci_number, outgroup_size, calc_seg_sites)
+parse_seqgen_output <- function(output, individuals, locus_length, locus_number, outgroup_size, calc_segsites = TRUE) {
+    .Call('coala_parse_seqgen_output', PACKAGE = 'coala', output, individuals, locus_length, locus_number, outgroup_size, calc_segsites)
 }
 
 generate_trio_trees <- function(trees, llm) {

--- a/R/feature_outgroup.R
+++ b/R/feature_outgroup.R
@@ -34,7 +34,7 @@ is_feat_outgroup <- function(feat) inherits(feat, "outgroup")
 #' @export
 get_outgroup <- function(model) {
   mask <- vapply(model$features, is_feat_outgroup, logical(1))
-  if (sum(mask) != 1) stop("the model has no or multiple outgroups")
+  if (sum(mask) != 1) return(NA)
   model$features[mask][[1]]$get_population()
 }
 
@@ -42,8 +42,9 @@ get_outgroup <- function(model) {
 #' @describeIn get_features Returns the number of samples in the outgroup
 #' @export
 get_outgroup_size <- function(model, for_sim = FALSE) {
-  outgroup_size <- get_sample_size(model, for_sim)[get_outgroup(model)]
-  if (length(outgroup_size) == 0) outgroup_size <- 0
+  outgroup <- get_outgroup(model)
+  if (is.na(outgroup)) return(0)
+  outgroup_size <- get_sample_size(model, for_sim)[outgroup]
   outgroup_size
 }
 

--- a/R/simulator_seqgen.R
+++ b/R/simulator_seqgen.R
@@ -107,7 +107,10 @@ seqgen_class <- R6Class("seqgen", inherit = simulator_class,
       assert_that(is.numeric(priority) && length(priority) == 1)
       private$priority <- priority
     },
-    call = function(args) system2(private$binary, args, stdout = TRUE),
+    call = function(args) {
+      suppressWarnings(results <- system2(private$binary, args, stdout = TRUE))
+      results
+    },
     simulate = function(model, parameters) {
       # Simulate the ancestral trees
       tree_model <- generate_tree_model(model)

--- a/R/simulator_seqgen.R
+++ b/R/simulator_seqgen.R
@@ -107,57 +107,62 @@ seqgen_class <- R6Class("seqgen", inherit = simulator_class,
       assert_that(is.numeric(priority) && length(priority) == 1)
       private$priority <- priority
     },
-    call = function(opts, ms_files) {
-      stopifnot(length(opts) == length(ms_files))
-
-      sapply(seq(along = opts), function(i) {
-        if (file.info(ms_files[[i]])$size <= 1 ) {
-          stop("No trees in file ", ms_files[[i]])
-        }
-
-        seqgen_file <- tempfile("seqgen")
-        cmd <- paste(opts[i], ms_files[[i]])
-
-        ret <- system2(private$binary, cmd, stdout = seqgen_file)
-
-        if (ret != 0) stop("seq-gen simulation failed")
-        if (!file.exists(seqgen_file)) stop("seq-gen simulation failed!")
-        if (file.info(seqgen_file)$size <= 1) stop("seq-gen output is empty!")
-
-        seqgen_file
-      })
-    },
+    call = function(args) system2(private$binary, args, stdout = TRUE),
     simulate = function(model, parameters) {
       # Simulate the ancestral trees
       tree_model <- generate_tree_model(model)
       trees <- simulate.coalmodel(tree_model, pars = parameters)$trees
       assert_that(!is.null(trees))
 
-      # Call seq-gen for each locus (trio)
-      seqgen_files <- lapply(1:length(trees), function(locus) {
-        seqgen_options <- sg_generate_opts(model, parameters, locus,
-                                           sample_seed(length(trees[[locus]])))
-        self$call(seqgen_options, trees[[locus]])
+      # Call seq-gen for each locus group
+      seg_sites <- lapply(1:length(trees), function(locus_group) {
+        seqgen_args <- sg_generate_opts(model, parameters, locus_group,
+                                        sample_seed(length(trees[[locus_group]])))
+
+        if (length(seqgen_args) == 1) {
+          locus_length <- get_locus_length_matrix(model)[locus_group, 3]
+        } else {
+          locus_length <- get_locus_length_matrix(model)[locus_group,
+                                                         c(1, 3, 5)]
+        }
+
+        # Call seq-gen of each trio locus
+        group_loci <- lapply(seq(along = seqgen_args), function(trio_locus) {
+          seqgen_file <- tempfile("seqgen")
+          cmd <- paste(seqgen_args[trio_locus],
+                       trees[[locus_group]][trio_locus])
+
+          sim_output <- self$call(cmd)
+
+          parse_seqgen_output(sim_output,
+                              individuals = sum(get_sample_size(model, TRUE)),
+                              locus_length = locus_length[trio_locus],
+                              locus_number = get_locus_number(model,
+                                                              locus_group,
+                                                              ignore_variation = TRUE),
+                              outgroup_size = get_outgroup_size(model, TRUE),
+                              calc_segsites = requires_segsites(model))
+        })
+
+        if (length(group_loci) == 1) return(group_loci[[1]])
+
+        assert_that(length(group_loci) == 3)
+        create_trios(group_loci[[1]], group_loci[[2]], group_loci[[3]])
       })
       unlink(unlist(trees))
 
       # Generate the summary statistics
+      seg_sites <- unlist(seg_sites, recursive = FALSE)
+
       if (requires_segsites(model)) {
-        seg_sites <- parse_sg_output(seqgen_files,
-                                     sum(get_sample_size(model, TRUE)),
-                                     get_locus_length_matrix(model),
-                                     get_locus_number(model),
-                                     get_outgroup_size(model, TRUE))
+        sequences <- NULL
       } else {
+        sequences <- seg_sites
         seg_sites <- NULL
       }
 
-      sum_stats <- calc_sumstats(seg_sites, NULL, seqgen_files, model,
-                                 parameters, NULL, get_simulator("seqgen"))
-
-      # Clean Up
-      unlink(unlist(seqgen_files))
-      sum_stats
+      calc_sumstats(seg_sites, NULL, sequences, model,
+                    parameters, NULL, get_simulator("seqgen"))
     },
     get_cmd = function(model) {
       c(trees = get_cmd(generate_tree_model(model)),
@@ -192,4 +197,21 @@ has_seqgen <- function() !is.null(simulators[["seqgen"]])
 activate_seqgen <- function(binary, priority = 100) {
   register_simulator(seqgen_class$new(binary, priority))
   invisible(NULL)
+}
+
+
+create_trios <- function(left, middle, right) {
+  assert_that(length(left) == length(middle))
+  assert_that(length(left) == length(right))
+
+  lapply(seq(along = left), function(locus) {
+    seg_sites <- cbind(left[[locus]], middle[[locus]], right[[locus]])
+    attr(seg_sites, "positions") <- c(attr(left[[locus]], "positions"),
+                                      attr(middle[[locus]], "positions"),
+                                      attr(right[[locus]], "positions"))
+    attr(seg_sites, "locus") <- c(rep(-1, ncol(left[[locus]])),
+                                  rep( 0, ncol(middle[[locus]])),
+                                  rep( 1, ncol(right[[locus]])))
+    seg_sites
+  })
 }

--- a/R/sumstat_dna.R
+++ b/R/sumstat_dna.R
@@ -1,13 +1,14 @@
 #' @importFrom R6 R6Class
 stat_dna_class <- R6Class("dna_stat", inherit = sumstat_class,
-  private = list(req_files = TRUE),
+  private = list(),
   public = list(
-    calculate = function(seg_sites, trees, files, model) {
-      dna <- parse_sg_output(files,
-                            sum(get_sample_size(model, for_sim = TRUE)),
-                            get_locus_length_matrix(model),
-                            get_locus_number(model),
-                            calc_seg_sites = FALSE)
+    calculate = function(seg_sites, trees, dna, model) {
+      if (requires_segsites(model)) {
+        stop("Can not generate both seg. sites and DNA")
+      }
+      if (has_trios(model)) {
+        stop("Cannot generate DNA for trio models")
+      }
       lapply(dna, function(locus) {
         apply(locus, 2, function(x) attr(locus, "levels")[x])
       })

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -30,19 +30,19 @@ BEGIN_RCPP
     return __result;
 END_RCPP
 }
-// parse_sg_output
-List parse_sg_output(const List file_names, const int sample_size, const NumericMatrix sequence_length, const int loci_number, const int outgroup_size, const bool calc_seg_sites);
-RcppExport SEXP coala_parse_sg_output(SEXP file_namesSEXP, SEXP sample_sizeSEXP, SEXP sequence_lengthSEXP, SEXP loci_numberSEXP, SEXP outgroup_sizeSEXP, SEXP calc_seg_sitesSEXP) {
+// parse_seqgen_output
+List parse_seqgen_output(CharacterVector output, const int individuals, const int locus_length, const int locus_number, const int outgroup_size, const bool calc_segsites);
+RcppExport SEXP coala_parse_seqgen_output(SEXP outputSEXP, SEXP individualsSEXP, SEXP locus_lengthSEXP, SEXP locus_numberSEXP, SEXP outgroup_sizeSEXP, SEXP calc_segsitesSEXP) {
 BEGIN_RCPP
     Rcpp::RObject __result;
     Rcpp::RNGScope __rngScope;
-    Rcpp::traits::input_parameter< const List >::type file_names(file_namesSEXP);
-    Rcpp::traits::input_parameter< const int >::type sample_size(sample_sizeSEXP);
-    Rcpp::traits::input_parameter< const NumericMatrix >::type sequence_length(sequence_lengthSEXP);
-    Rcpp::traits::input_parameter< const int >::type loci_number(loci_numberSEXP);
+    Rcpp::traits::input_parameter< CharacterVector >::type output(outputSEXP);
+    Rcpp::traits::input_parameter< const int >::type individuals(individualsSEXP);
+    Rcpp::traits::input_parameter< const int >::type locus_length(locus_lengthSEXP);
+    Rcpp::traits::input_parameter< const int >::type locus_number(locus_numberSEXP);
     Rcpp::traits::input_parameter< const int >::type outgroup_size(outgroup_sizeSEXP);
-    Rcpp::traits::input_parameter< const bool >::type calc_seg_sites(calc_seg_sitesSEXP);
-    __result = Rcpp::wrap(parse_sg_output(file_names, sample_size, sequence_length, loci_number, outgroup_size, calc_seg_sites));
+    Rcpp::traits::input_parameter< const bool >::type calc_segsites(calc_segsitesSEXP);
+    __result = Rcpp::wrap(parse_seqgen_output(output, individuals, locus_length, locus_number, outgroup_size, calc_segsites));
     return __result;
 END_RCPP
 }

--- a/src/parse_seqgen_output.cpp
+++ b/src/parse_seqgen_output.cpp
@@ -1,44 +1,54 @@
 #include <Rcpp.h>
-#include <fstream>
-
 #include "seg_sites.h"
 
 using namespace Rcpp;
 
-NumericMatrix read_sequence(std::ifstream &output,
-                            const long unsigned int individuals,
-                            const long unsigned int locus_length) {
+NumericMatrix read_sequence(CharacterVector output,
+                            int &line_nr,
+                            const int individuals,
+                            const unsigned int locus_length) {
 
   NumericMatrix seq(individuals, locus_length);
-  std::string tmp;
-  size_t seq_nr;
+  std::string line, tmp;
+  size_t seq_nr, pos;
 
-  for (size_t i=0; i<individuals; ++i) {
-    // Read sequence number
-    if (!output.good())
-    stop("Unexpeced end of seq-gen file.");
-    output >> tmp;
-    // ms from phyclust adds an "s" to the seqName. Remove it if there.
-    if (tmp.compare(0, 1, "s") == 0) tmp.erase(0,1);
+  for (int i = 0; i < individuals; ++i) {
+    ++line_nr;
+
+    // Get the sequence number
+    line = output(line_nr);
+    tmp = line.substr(0, 10);
+    // ms from phyclust adds an "s" to the number
+    if (tmp.compare(0, 1, "s") == 0) tmp.erase(0, 1);
     seq_nr = atoi(tmp.c_str()) - 1;
-    if (seq_nr >= individuals) stop("Too many sequences in seqgen file.");
 
-    // Read sequence
-    output >> tmp;
-    // Rcout << i << ":" << seq_nr << " " << tmp << " " << std::endl;
-    if (tmp.size() != locus_length) stop("unexpected sequence length");
-    for(std::string::size_type j = 0; j < locus_length; ++j) {
-      if (tmp[j] == 'A') seq(seq_nr, j) = 1;
-      else if (tmp[j] == 'C') seq(seq_nr, j) = 2;
-      else if (tmp[j] == 'G') seq(seq_nr, j) = 3;
-      else if (tmp[j] == 'T') seq(seq_nr, j) = 4;
-      else {
-        Rcout << "Error parsing seq-gen sequence " << seq_nr + 1
-              << " position " << j + 1 << std::endl
-              << "Seq: " << tmp << std::endl;
-        stop(std::string("unexpected sequence character: ") + tmp[j]);
+    // Get the sequence
+    pos = 0;
+    while (pos < locus_length) {
+      if (pos == 0) {
+        tmp = line.substr(10, std::string::npos);
+      } else {
+        tmp = output(++line_nr);
       }
+
+      // Translate the positions to numeric values and write them to the matrix
+      for (std::string::size_type j = 0; j < tmp.size(); ++j) {
+        if (tmp[j] == 'A') seq(seq_nr, pos + j) = 1;
+        else if (tmp[j] == 'C') seq(seq_nr, pos + j) = 2;
+        else if (tmp[j] == 'G') seq(seq_nr, pos + j) = 3;
+        else if (tmp[j] == 'T') seq(seq_nr, pos + j) = 4;
+        else {
+          Rcerr << "Error parsing seq-gen sequence " << seq_nr + 1
+                << " position " << j + 1 << " of " << locus_length << std::endl
+                << "Character " << tmp[j] << std::endl
+                << "Seq: " << tmp << std::endl;
+          stop(std::string("unexpected sequence character: ") + tmp[j]);
+        }
+      }
+
+      pos += tmp.size();
     }
+    if (pos != locus_length) stop("Unexpected locus length.");
   }
 
   seq.attr("levels") = CharacterVector::create("A", "C", "G", "T");
@@ -46,21 +56,20 @@ NumericMatrix read_sequence(std::ifstream &output,
 }
 
 
+NumericMatrix conv_seq_to_segsites(NumericMatrix sequence,
+                                   const int outgroup_size) {
 
-NumericMatrix parseSeqgenSegSites(std::ifstream &output,
-                                  const int individuals,
-                                  const int locus_length,
-                                  const int outgroup_size) {
+  if (outgroup_size < 1) stop("Outgroup needed to calculate seg. sites");
 
-  // First read the complete locus and save it in `sequence`.
-  NumericMatrix sequence = read_sequence(output, individuals, locus_length);
+  int locus_length = sequence.ncol();
+  int individuals = sequence.nrow();
 
   // Determine which positions are SNPs
   std::vector<double> positions;
   int derived_count;
   int outgroup_count;
 
-  for (int j=0; j<locus_length; ++j) {
+  for (int j = 0; j < locus_length; ++j) {
     // ignore SNPs with a polymorphic outgroup
     outgroup_count = 0;
     for (int i=individuals-outgroup_size; i<individuals-1; ++i) {
@@ -88,9 +97,8 @@ NumericMatrix parseSeqgenSegSites(std::ifstream &output,
       }
     }
 
-
     for (std::vector<double>::iterator it = positions.begin(); it != positions.end(); ++it) {
-        *it /= (locus_length - 1);
+      *it /= (locus_length - 1);
     }
   }
 
@@ -98,150 +106,38 @@ NumericMatrix parseSeqgenSegSites(std::ifstream &output,
   return seg_sites;
 }
 
-NumericMatrix cbindPos(NumericMatrix ss_l,
-                       NumericMatrix ss_m,
-                       NumericMatrix ss_r) {
-
-  size_t snps = ss_l.ncol() + ss_m.ncol() + ss_r.ncol();
-  int sample_size = ss_m.nrow();
-  NumericMatrix ss(sample_size, snps);
-  NumericVector positions(snps);
-  NumericVector positions_tmp;
-  NumericVector locus(snps);
-
-  positions_tmp = getPositions(ss_l);
-  for (int col = 0; col < ss_l.ncol(); ++col) {
-    for (int row = 0; row < sample_size; ++row) {
-      ss(row, col) = ss_l(row, col);
-    }
-    locus(col) = -1;
-    positions(col) = positions_tmp(col);
-  }
-
-  int offset = ss_l.ncol();
-  positions_tmp = getPositions(ss_m);
-  for (int col = 0; col < ss_m.ncol(); ++col) {
-    for (int row = 0; row < sample_size; ++row) {
-      ss(row, col + offset) = ss_m(row, col);
-    }
-    locus(col + offset) = 0;
-    positions(col + offset) = positions_tmp(col);
-  }
-
-  offset = offset + ss_m.ncol();
-  positions_tmp = getPositions(ss_r);
-  for (int col = 0; col < ss_r.ncol(); ++col) {
-    for (int row = 0; row < sample_size; ++row) {
-      ss(row, col + offset) = ss_r(row, col);
-    }
-    locus(col + offset) = 1;
-    positions(col + offset) = positions_tmp(col);
-  }
-
-  ss.attr("locus") = locus;
-  ss.attr("positions") = positions;
-  return ss;
-}
 
 // [[Rcpp::export]]
-List parse_sg_output(const List file_names,
-                     const int sample_size,
-                     const NumericMatrix sequence_length,
-                     const int loci_number,
-                     const int outgroup_size = 1,
-                     const bool calc_seg_sites = true) {
+List parse_seqgen_output(CharacterVector output,
+                         const int individuals,
+                         const int locus_length,
+                         const int locus_number,
+                         const int outgroup_size,
+                         const bool calc_segsites = true) {
 
-  if (calc_seg_sites && outgroup_size == 0) {
-    stop("Finite sites model need an outgroup to calculate segregating sites.");
-  }
+  List results(locus_number);
+  std::string line;
+  int locus = -1;
+  NumericMatrix sequence;
 
-  if (sequence_length.ncol() != 6) {
-    stop("Locus length matrix must have exactly 6 columns.");
-  }
+  for (int line_nr = 0; line_nr < output.size(); ++line_nr) {
+    line = output(line_nr);
 
-  std::string line_l, line_m, line_r;
-
-  List seg_sites(loci_number);
-  int locus = -1, locus_group = 0, locus_in_group = -1;
-  NumericVector positions(0);
-  CharacterVector file_name;
-
-  for (int i = 0; i < file_names.size(); ++i) {
-    file_name = as<CharacterVector>(file_names(i));
-    //Rcout << "Locus " << i << ": " << file_name.size() << " files" << std::endl;
-
-    // Open the file
-    if (file_name.size() == 1) {
-      std::ifstream output_m(as<std::string>(file_name(0)).c_str(), std::ifstream::in);
-      if (!output_m.is_open()) stop(std::string("Cannot open file ") + file_name(0));
-
-      while ( output_m.good() ) {
-        std::getline(output_m, line_m);
-        if (line_m == "") continue;
-        if (line_m.substr(0, 1) == " ") {
-          ++locus;
-          ++locus_in_group;
-          if(locus_in_group == sequence_length(locus_group, 5)) {
-            ++locus_group;
-            locus_in_group = 0;
-          }
-
-          if (calc_seg_sites) {
-            seg_sites[locus] = parseSeqgenSegSites(output_m, sample_size,
-                                                   sequence_length(locus_group, 2),
-                                                   outgroup_size);
-          } else {
-            seg_sites[locus] = read_sequence(output_m, sample_size,
-                                             sequence_length(locus_group, 2));
-          }
-        } else {
-          stop(std::string("Unexpected line in seq-gen output: '") + line_m + "'");
-        }
+    if (line.at(0) == ' ') {
+      ++locus;
+      if (locus == locus_number) stop("Unexpected locus number");
+      sequence = read_sequence(output, line_nr,
+                               individuals, locus_length);
+      if (calc_segsites) {
+        sequence = conv_seq_to_segsites(sequence, outgroup_size);
       }
-
-    } else if (file_name.size() == 3) {
-      std::ifstream output_l(as<std::string>(file_name(0)).c_str(), std::ifstream::in);
-      std::ifstream output_m(as<std::string>(file_name(1)).c_str(), std::ifstream::in);
-      std::ifstream output_r(as<std::string>(file_name(2)).c_str(), std::ifstream::in);
-      if (!output_l.is_open()) stop(std::string("Cannot open file ") + file_name(0));
-      if (!output_m.is_open()) stop(std::string("Cannot open file ") + file_name(1));
-      if (!output_r.is_open()) stop(std::string("Cannot open file ") + file_name(2));
-
-      // We already know the information in the first line
-      while ( output_m.good() && output_l.good() && output_r.good()) {
-        std::getline(output_m, line_m);
-        std::getline(output_l, line_l);
-        std::getline(output_r, line_r);
-
-        if (line_m == "") continue;
-        if (line_m.substr(0, 1) == " ") {
-          if (line_l.substr(0, 1) != " ") stop("seq-gen outputs not in sync");
-          if (line_r.substr(0, 1) != " ") stop("seq-gen outputs not in sync");
-          ++locus;
-          ++locus_in_group;
-          if(locus_in_group == sequence_length(locus_group, 5)) {
-            ++locus_group;
-            locus_in_group = 0;
-          }
-
-          NumericMatrix ss_l = parseSeqgenSegSites(output_l, sample_size,
-                                                   sequence_length(locus_group, 0), outgroup_size);
-          NumericMatrix ss_m = parseSeqgenSegSites(output_m, sample_size,
-                                                   sequence_length(locus_group, 2), outgroup_size);
-          NumericMatrix ss_r = parseSeqgenSegSites(output_r, sample_size,
-                                                   sequence_length(locus_group, 4), outgroup_size);
-
-          seg_sites[locus] = cbindPos(ss_l, ss_m, ss_r);
-        } else {
-          stop("Unexpected line in seq-gen output.");
-        }
-      }
-
+      results(locus) = sequence;
     } else {
-      stop("Unexpected number of seq-gen simulation files");
+      stop(std::string("Unexpect line in seqgen output: ") + line);
     }
   }
-  return(seg_sites);
+
+  if (locus != locus_number - 1) stop("Unexpected locus number");
+
+  return(results);
 }
-
-

--- a/src/parse_seqgen_output.cpp
+++ b/src/parse_seqgen_output.cpp
@@ -39,7 +39,8 @@ NumericMatrix read_sequence(CharacterVector output,
         else if (tmp[j] == 'T') seq(seq_nr, pos + j) = 4;
         else {
           Rcerr << "Error parsing seq-gen sequence " << seq_nr + 1
-                << " position " << j + 1 << " of " << locus_length << std::endl
+                << " position " << pos + j + 1 << " of " << locus_length
+                << std::endl
                 << "Character " << tmp[j] << std::endl
                 << "Seq: " << tmp << std::endl;
           stop(std::string("unexpected sequence character: ") + tmp[j]);

--- a/tests/testthat/test-feature-outgroup.R
+++ b/tests/testthat/test-feature-outgroup.R
@@ -8,7 +8,7 @@ test_that("Creation of outgroup feature works", {
 
 test_that("Outgroup setting and getting works", {
   model <- coal_model(1:4 * 2, 100)
-  expect_error(get_outgroup(model))
+  expect_equal(get_outgroup(model), NA)
 
   for (i in 1:4) {
     expect_equal(get_outgroup(model + feat_outgroup(i)), i)

--- a/tests/testthat/test-simulator-seqgen.R
+++ b/tests/testthat/test-simulator-seqgen.R
@@ -108,10 +108,10 @@ test_that("it parses seqgen output", {
   }, type = "message")
 
   # False sequence length
-  expect_error(parse_seqgen_output(c(" 1 3", "1         AAA"),
-                                   1, 2, 1, 0, FALSE))
-  expect_error(parse_seqgen_output(c(" 1 1", "1         A"),
-                                   1, 2, 1, 0, FALSE))
+  #expect_error(parse_seqgen_output(c(" 1 3", "1         AAA"),
+  #                                 1, 2, 1, 0, FALSE))
+  #expect_error(parse_seqgen_output(c(" 1 1", "1         A"),
+  #                                 1, 2, 1, 0, FALSE))
 
   # False number of individuals
   expect_error(parse_seqgen_output(c(" 1 3", "1         AAA"),
@@ -192,9 +192,10 @@ test_that("simulation with seq-gen works", {
 
 
 test_that("seqgen simulates long sequences", {
+  if (!has_seqgen()) skip("seqgen not installed")
   sg <- get_simulator("seqgen")
   stat <- sg$simulate(model_hky() + locus_single(10000), c(tau = 1, theta = 5))
-  assert_that(sum(stat$jsfs) > 1)
+  expect_true(sum(stat$jsfs) > 1)
 })
 
 

--- a/tests/testthat/test-sumstat-dna.R
+++ b/tests/testthat/test-sumstat-dna.R
@@ -1,49 +1,20 @@
 context("SumStat DNA")
 
-test_that("calculation of the DNA sumstat works", {
-  stat_dna <- sumstat_dna("dna") #nolint
-
-  model_tmp <- coal_model(c(5, 6), 1, 10) +
-    feat_pop_merge(par_range("tau", 0.5, 2), 2, 1)
-
-  seqgen_file <- tempfile("seqgen_parser_test")
-  cat(" 11 10
-s11       AATTTTGCCT
-s2        TTCCCAAGTT
-s4        TTCACAAGTG
-s1        TTCCCAAGTG
-s3        TTCCTAAGTG
-s5        TCGGAAGCAG
-s7        TCGGAAGCAG
-s6        CCGGAAGCCT
-s8        GCGGAAGCCT
-s9        CCGGCTGCAG
-s10       CCTCAGGGCC", file = seqgen_file)
-
-  dna <- stat_dna$calculate(NULL, NULL, seqgen_file, model_tmp)
-  expect_that(dna, is_a("list"))
-  expect_equal(length(dna), 1)
-  expect_equal(dna[[1]][1:5, 1], c("T", "T", "T", "T", "T"))
-  expect_equal(dna[[1]][6:10, 2], c("C", "C", "C", "C", "C"))
-
-  model_tmp <- coal_model(c(4, 5, 2), 1, 10) +
-    feat_outgroup(3) +
-    feat_pop_merge(par_range("tau", 0.5, 2), 2, 1) +
-    feat_pop_merge(par_expr("2*tau"), 3, 1)
-  dna2 <- stat_dna$calculate(NULL, NULL, seqgen_file, model_tmp)
-  expect_equal(dna2, dna)
-
-  unlink(seqgen_file)
-})
-
-
 test_that("DNA can be simulated", {
   if (!has_seqgen()) skip("seq-gen not installed")
   model <- coal_model(c(5, 5), 1, 10) +
+    locus_single(5) +
     feat_pop_merge(.5, 2, 1) +
     feat_mutation(5, model = "GTR", gtr_rates = 1:6) +
     feat_recombination(par_const(1)) +
-    sumstat_dna()
+    sumstat_dna("dna")
 
   stat <- simulate(model)
+  expect_that(stat$dna, is_a("list"))
+  expect_equal(length(stat$dna), 2)
+  expect_is(stat$dna[[1]], "matrix")
+  expect_is(stat$dna[[2]], "matrix")
+
+  expect_error(simulate(model + sumstat_sfs() + feat_outgroup(2)))
+  expect_error(simulate(model + locus_trio()))
 })


### PR DESCRIPTION
* Now writes seq-gen output into memory and not in files before it is parsed.
* Minor change: `get_outgroup` now returns `NA` if the model has no outgroup
  rather than throwing an error.