### PR TITLE
Make sure all SNPs are polymorphic in the ehh pop

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: coala
-Version: 0.1.1.9003
-Date: 2015-09-02
+Version: 0.1.1.9004
+Date: 2015-09-14
 License: MIT + file LICENSE
 Title: A Framework for Coalescent Simulation
 Authors@R: c(

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,10 @@
+coala 0.1.1.9004
+----------------
+
+* Fix: Remove SNPs that were not polymorphic in the given population before
+  calulating EHH based statistics.
+
+
 coala 0.1.1.9003
 ----------------
 

--- a/R/sumstat_ihh.R
+++ b/R/sumstat_ihh.R
@@ -54,7 +54,7 @@ stat_ihh_class <- R6Class("stat_ihh", inherit = sumstat_class,
     },
     create_rehh_data = function(seg_sites, pos, ind) {
       assert_that(is.matrix(seg_sites))
-      snp_mask <- self$create_snp_mask(seg_sites)
+      snp_mask <- self$create_snp_mask(seg_sites, ind)
       rehh_data <- new("haplohh")
       rehh_data@haplo <- seg_sites[ind, snp_mask, drop = FALSE] + 1
       rehh_data@position <- pos[snp_mask]
@@ -64,12 +64,15 @@ stat_ihh_class <- R6Class("stat_ihh", inherit = sumstat_class,
       rehh_data@nsnp <- length(rehh_data@position)
       rehh_data
     },
-    create_snp_mask = function(seg_sites) {
-      n_snps <- ncol(seg_sites)
+    create_snp_mask = function(seg_sites, ind) {
+      polym_in_sample <- apply(seg_sites[ind, , drop = FALSE], 2, function(x) {
+        any(0 == x) & any(1 == x)
+      })
+      n_snps <- sum(polym_in_sample)
       if (n_snps < private$max_snps || !is.na(private$position)) {
-        return(rep(TRUE, n_snps))
+        return(polym_in_sample)
       }
-      sample.int(n_snps, private$max_snps, replace = FALSE)
+      sample(which(polym_in_sample), private$max_snps, replace = FALSE)
     }
   )
 )

--- a/tests/testthat/test-sumstat-iHH.R
+++ b/tests/testthat/test-sumstat-iHH.R
@@ -13,17 +13,29 @@ test_that("generation of rehh data works", {
   skip_if_not_installed("rehh")
   stat_ihh <- sumstat_ihh(population = 1)
   rehh_data <- stat_ihh$create_rehh_data(seg_sites, pos, 1:4)
-  expect_equivalent(rehh_data@haplo, seg_sites + 1)
-  expect_equal(rehh_data@position, pos)
-  expect_equal(rehh_data@snp.name, as.character(1:5))
+  expect_equivalent(rehh_data@haplo, seg_sites[,-c(1, 3)] + 1)
+  expect_equal(rehh_data@position, pos[-c(1, 3)])
+  expect_equal(rehh_data@snp.name, as.character(1:3))
   expect_equal(rehh_data@nhap, 4)
-  expect_equal(rehh_data@nsnp, 5)
+  expect_equal(rehh_data@nsnp, 3)
 
   rehh_data <- stat_ihh$create_rehh_data(matrix(0, 4, 0), numeric(), 1:4)
   expect_equal(rehh_data@haplo, matrix(0, 4, 0))
 
   rehh_data <- stat_ihh$create_rehh_data(seg_sites, pos, numeric())
-  expect_equal(rehh_data@haplo, matrix(0, 0, 5))
+  expect_equal(rehh_data@haplo, matrix(0, 0, 0))
+})
+
+
+test_that("SNPs not segregating in individuals are removed from rehh_data", {
+  skip_if_not_installed("rehh")
+  stat_ihh <- sumstat_ihh(population = 1)
+  rehh_data <- stat_ihh$create_rehh_data(seg_sites, pos, 1:2)
+  expect_equivalent(rehh_data@haplo, seg_sites[1:2, c(2, 4, 5)] + 1)
+  expect_equal(rehh_data@position, pos[c(2, 4, 5)])
+  expect_equal(rehh_data@snp.name, as.character(1:3))
+  expect_equal(rehh_data@nhap, 2)
+  expect_equal(rehh_data@nsnp, 3)
 })
 
 
@@ -38,14 +50,20 @@ test_that("selection of snps works", {
   rehh_data <- stat_ihh$create_rehh_data(seg_sites, pos, 1:4)
   expect_equal(dim(rehh_data@haplo), c(4, 3))
   expect_equal(rehh_data@nsnp, 3)
+
+  stat_ihh <- sumstat_ihh(population = 1, max_snps = 2)
+  rehh_data <- stat_ihh$create_rehh_data(seg_sites, pos, 1:2)
+  expect_equal(dim(rehh_data@haplo), c(2, 2))
+  expect_equal(rehh_data@nsnp, 2)
+  expect_equal(rehh_data@nhap, 2)
 })
 
 
 test_that("all snps are used if a position is given", {
   stat_ihh <- sumstat_ihh(population = 1, max_snps = 2, position = .5)
   rehh_data <- stat_ihh$create_rehh_data(seg_sites, pos, 1:4)
-  expect_equal(dim(rehh_data@haplo), c(4, 5))
-  expect_equal(rehh_data@nsnp, 5)
+  expect_equal(dim(rehh_data@haplo), c(4, 3))
+  expect_equal(rehh_data@nsnp, 3)
   expect_equal(rehh_data@nhap, 4)
 })
 
@@ -57,7 +75,7 @@ test_that("calculation of ihh works", {
   expect_that(ihh, is_a("list"))
   expect_equal(length(ihh), 1)
   expect_that(ihh[[1]], is_a("matrix"))
-  expect_equal(dim(ihh[[1]]), c(5, 3))
+  expect_equal(dim(ihh[[1]]), c(3, 3))
 
   stat_ihh <- sumstat_ihh(position = 0.5)
   ihh2 <- stat_ihh$calculate(list(seg_sites), NULL, NULL, model)

--- a/tests/testthat/test-sumstat-nSL.R
+++ b/tests/testthat/test-sumstat-nSL.R
@@ -15,7 +15,7 @@ test_that("calculation of nSL works", {
   expect_that(nsl, is_a("list"))
   expect_equal(length(nsl), 1)
   expect_that(nsl[[1]], is_a("numeric"))
-  expect_equal(length(nsl[[1]]), 5)
+  expect_equal(length(nsl[[1]]), 3)
 
   stat_nsl <- sumstat_nSL(position = 0.5) #nolint
   nsl2 <- stat_nsl$calculate(list(seg_sites), NULL, NULL, model)


### PR DESCRIPTION
* Fix: Remove SNPs that were not polymorphic in the given population before
  calulating EHH based statistics.