### PR TITLE
Restrict features to a subgroup of loci

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: coala
-Version: 0.4.1.9005
+Version: 0.4.1.9006
 License: MIT + file LICENSE
 Title: A Framework for Coalescent Simulation
 Authors@R: c(

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,9 @@ coala 0.5.0
 * Major interal refactoring on how simulators interface with coala (#174).
 * Support for calculating an expanded version of MCMF (#173, #179). This
   feature was contributed by Jorge E. Amaya Romero (@jorgeamaya).
+* Introduces the optional `locus_group` argument for features. Using it, 
+  features can be defined only for a subset of the loci in the model
+  (#161, #181). Thanks to @andrewparkermorgan for suggesting this feature.
 
 
 

--- a/R/feature.R
+++ b/R/feature.R
@@ -6,11 +6,16 @@ feature_class <- R6Class("feature", inherit = model_part,
     population = NULL,
     time = NULL,
     rate = NA,
+    locus_group = NULL,
     set_population = function(population, expected_length = 1) {
       assert_that(identical(population, "all") || is.numeric(population))
       assert_that(identical(population, "all") ||
                     length(population) == expected_length)
       private$population <- population
+    },
+    set_locus_group = function(locus_group) {
+      assert_that(identical(locus_group, "all") || is.numeric(locus_group))
+      private$locus_group <- locus_group
     },
     add_parameter = function(parameter, required = TRUE, add_par = TRUE) {
       expr <- NA
@@ -31,14 +36,16 @@ feature_class <- R6Class("feature", inherit = model_part,
     }
   ),
   public = list(
-    initialize = function(rate, population, time) {
+    initialize = function(rate, population, time, locus_group) {
       if (!missing(rate)) private$rate <- private$add_parameter(rate)
       if (!missing(time)) private$time <- private$add_parameter(time)
       if (!missing(population)) private$set_population(population)
+      if (!missing(locus_group)) private$set_locus_group(locus_group)
     },
     get_parameters = function() private$parameter,
     get_population = function() private$population,
     get_time = function() private$time,
+    get_locus_group = function() private$locus_group,
     reset_parameters = function() private$parameter <- list(),
     print = function() {
       cat("Feature of type", private$feature_table$type[1], "\n")

--- a/R/feature_growth.R
+++ b/R/feature_growth.R
@@ -30,7 +30,7 @@ growth_class <- R6Class("growth", inherit = feature_class,
 #' @export
 #' @seealso For instantaneous population size
 #'          changes: \code{\link{feat_size_change}}
-#' @family features
+#' @template feature
 #' @examples
 #' # Simulate a haploid population that has been expanding for
 #' # the last 2*Ne generations
@@ -40,8 +40,14 @@ growth_class <- R6Class("growth", inherit = feature_class,
 #'   feat_mutation(10) +
 #'   sumstat_sfs()
 #' simulate(model)
-feat_growth <- function(rate, population = "all", time="0") {
-  growth_class$new(rate, population, time)
+feat_growth <- function(rate,
+                        population = "all",
+                        time = "0",
+                        locus_group = "all") {
+
+  growth_class$new(rate, population, time,
+                   locus_group = locus_group)
+
 }
 
 

--- a/R/feature_ignore_singletons.R
+++ b/R/feature_ignore_singletons.R
@@ -13,9 +13,8 @@ ign_singletons_class <- R6Class("ign_singletons", inherit = feature_class)
 #' allele is observed exactly once in all sequences, regardless of the
 #' population structure.
 #'
-#' @return The feature, which can be added to a model using `+`.
 #' @export
-#' @family features
+#' @template feature
 #' @examples
 #' model <- coal_model(2, 1) +
 #'   feat_mutation(10) +
@@ -24,8 +23,8 @@ ign_singletons_class <- R6Class("ign_singletons", inherit = feature_class)
 #' # In this model, all mutations are singletons. Therefore,
 #' # the number of mutations is 0 when removing singletons:
 #' simulate(model)$n_mut
-feat_ignore_singletons <- function() {
-  ign_singletons_class$new()
+feat_ignore_singletons <- function(locus_group = "all") {
+  ign_singletons_class$new(locus_group = locus_group)
 }
 
 

--- a/R/feature_migration.R
+++ b/R/feature_migration.R
@@ -1,8 +1,9 @@
 migration_class <- R6Class("migration", inherit = feature_class,
   private = list(rate = NA),
   public = list(
-    initialize = function(rate, pop_from, pop_to, time, symmetric = FALSE) {
-      super$initialize(rate = rate, time = time)
+    initialize = function(rate, pop_from, pop_to, time,
+                          symmetric = FALSE, locus_group) {
+      super$initialize(rate = rate, time = time, locus_group = locus_group)
 
       if (symmetric) {
         private$population <- "all"
@@ -48,7 +49,7 @@ migration_class <- R6Class("migration", inherit = feature_class,
 #'        rate is set. The rate applies to the time past warts
 #'        of the time point, until it is changed again.
 #' @export
-#' @family features
+#' @template feature
 #'
 #' @examples
 #' # Asymmetric migration between two populations:
@@ -67,15 +68,18 @@ migration_class <- R6Class("migration", inherit = feature_class,
 #'   sumstat_sfs()
 #' simulate(model)
 feat_migration <- function(rate, pop_from = NULL, pop_to = NULL,
-                           symmetric = FALSE, time = "0") {
+                           symmetric = FALSE, time = "0",
+                           locus_group = "all") {
   if (symmetric) {
     if (!(is.null(pop_from) && is.null(pop_to))) {
       warning("Ignoring 'pop_form' and 'pop_to' because 'symmetric' is TRUE")
     }
-    return(migration_class$new(rate, time = time, symmetric = TRUE))
+    return(migration_class$new(rate, time = time, symmetric = TRUE,
+                               locus_group = locus_group))
   }
 
-  migration_class$new(rate, pop_from, pop_to, time)
+  migration_class$new(rate, pop_from, pop_to, time,
+                      locus_group = locus_group)
 }
 
 

--- a/R/feature_mutation.R
+++ b/R/feature_mutation.R
@@ -121,6 +121,16 @@ mutation_class <- R6Class("mutation", inherit = feature_class,
 #' model <- coal_model(5, 1) + feat_mutation(5) + sumstat_seg_sites()
 #' simulate(model)
 #'
+#' # A model with a mutation of 5.0 for the first 10 loci, and 7.5 for the
+#' # second 10 loci
+#' model <- coal_model(4) +
+#'   locus_averaged(10, 100) +
+#'   locus_averaged(10, 100) +
+#'   feat_mutation(5.0, locus_group = 1) +
+#'   feat_mutation(7.5, locus_group = 2) +
+#'   sumstat_seg_sites()
+#' simulate(model)
+#'
 #' # A model with 7 mutations per locus:
 #' model <- coal_model(5, 1) +
 #'   feat_mutation(7, fixed = TRUE) +

--- a/R/feature_mutation.R
+++ b/R/feature_mutation.R
@@ -9,8 +9,10 @@ mutation_class <- R6Class("mutation", inherit = feature_class,
   ),
   public = list(
     initialize = function(rate, model, base_frequencies,
-                          tstv_ratio, gtr_rates, fixed) {
+                          tstv_ratio, gtr_rates, fixed,
+                          locus_group) {
       private$rate <- private$add_parameter(rate, add_par = FALSE)
+      private$set_locus_group(locus_group)
 
       assert_that(length(model) == 1)
       assert_that(any(model == c("IFS", "HKY", "GTR")))
@@ -91,7 +93,7 @@ mutation_class <- R6Class("mutation", inherit = feature_class,
 #' @seealso For using rates that variate between the loci in a model:
 #'   \code{\link{par_variation}}, \code{\link{par_zero_inflation}}
 #' @seealso For adding recombination: \code{\link{feat_recombination}}.
-#' @family features
+#' @template feature
 #'
 #' @section Mutation Models:
 #' The infinite sites mutation (\strong{IFS}) model is a frequently used simplification
@@ -147,10 +149,12 @@ feat_mutation <- function(rate,
                           base_frequencies = NA,
                           tstv_ratio = NA,
                           gtr_rates = NA,
-                          fixed_number = FALSE) {
+                          fixed_number = FALSE,
+                          locus_group = "all") {
 
   mutation_class$new(rate, model, base_frequencies,
-                     tstv_ratio, gtr_rates, fixed_number)
+                     tstv_ratio, gtr_rates, fixed_number,
+                     locus_group = locus_group)
 }
 
 is_feat_mutation <- function(feat) any("mutation" == class(feat))

--- a/R/feature_outgroup.R
+++ b/R/feature_outgroup.R
@@ -1,7 +1,8 @@
 outgroup_class <- R6Class("outgroup", inherit = feature_class,
   public = list(
-    initialize = function(population) {
+    initialize = function(population, locus_group) {
       private$set_population(population)
+      private$set_locus_group(locus_group)
     },
     print = function() {
       cat("Outgroup: Population", private$population, "\n")
@@ -19,7 +20,7 @@ outgroup_class <- R6Class("outgroup", inherit = feature_class,
 #'
 #' @param population The population that is marked as outgroup.
 #' @export
-#' @family features
+#' @template feature
 #' @examples
 #' # A simple finite sites model
 #' model <- coal_model(c(4, 6, 1), 2, 10) +
@@ -27,8 +28,8 @@ outgroup_class <- R6Class("outgroup", inherit = feature_class,
 #'    feat_pop_merge(0.5, 2, 1) +
 #'    feat_pop_merge(2, 3, 1) +
 #'    feat_mutation(5, model = "GTR", gtr_rates = 1:6)
-feat_outgroup <- function(population) {
-  outgroup_class$new(population)
+feat_outgroup <- function(population, locus_group = "all") {
+  outgroup_class$new(population, locus_group = locus_group)
 }
 
 is_feat_outgroup <- function(feat) inherits(feat, "outgroup")

--- a/R/feature_pop_merge.R
+++ b/R/feature_pop_merge.R
@@ -1,8 +1,9 @@
 pop_merge_class <- R6Class("pop_merge", inherit = feature_class,
   public = list(
-    initialize = function(time, pop_from, pop_to) {
+    initialize = function(time, pop_from, pop_to, locus_group) {
       private$time <- private$add_parameter(time)
       private$set_population(c(from = pop_from, to = pop_to), 2)
+      private$set_locus_group(locus_group)
     },
     print = function() {
       cat("Merge of pop", private$population[1],
@@ -30,7 +31,7 @@ pop_merge_class <- R6Class("pop_merge", inherit = feature_class,
 #'        the population in which the speciation event occurs.
 #' @param time The time at which the merge occurs.
 #' @export
-#' @family features
+#' @template feature
 #' @examples
 #' # Two population which merge after 0.5 time units:
 #' model <- coal_model(c(25,25), 1) +
@@ -43,8 +44,9 @@ pop_merge_class <- R6Class("pop_merge", inherit = feature_class,
 #' model_iwm <- model +
 #'   feat_migration(.75, symmetric = TRUE)
 #' simulate(model_iwm)
-feat_pop_merge <- function(time, pop_source, pop_target) {
-  pop_merge_class$new(time, pop_source, pop_target)
+feat_pop_merge <- function(time, pop_source, pop_target, locus_group = "all") {
+  pop_merge_class$new(time, pop_source, pop_target,
+                      locus_group = locus_group)
 }
 
 #' @describeIn conv_to_ms_arg Feature conversion

--- a/R/feature_recombination.R
+++ b/R/feature_recombination.R
@@ -21,7 +21,7 @@ recombination_class <- R6Class("recombination", inherit = feature_class,
 #'        recombination event within the locus occurs in one generation.
 #' @return The feature, which can be added to a model using `+`.
 #' @export
-#' @family features
+#' @template feature
 #' @seealso For adding recombination: \code{\link{feat_mutation}}.
 #'
 #' @examples
@@ -31,8 +31,8 @@ recombination_class <- R6Class("recombination", inherit = feature_class,
 #'   feat_mutation(5) +
 #'   sumstat_sfs()
 #' simulate(model)
-feat_recombination <- function(rate) {
-  recombination_class$new(rate)
+feat_recombination <- function(rate, locus_group = "all") {
+  recombination_class$new(rate, locus_group = locus_group)
 }
 
 #' @describeIn conv_to_ms_arg Feature conversion

--- a/R/feature_sample.R
+++ b/R/feature_sample.R
@@ -2,6 +2,8 @@ sample_class <- R6Class("sample", inherit = feature_class,
   private = list(size = NA, ploidy = NA),
   public = list(
     initialize = function(sizes, ploidy, time) {
+      private$set_locus_group("all")
+
       assert_that(is.numeric(sizes))
       assert_that(length(sizes) >= 1)
       private$size <- sizes
@@ -36,8 +38,8 @@ sample_class <- R6Class("sample", inherit = feature_class,
 #' @param ploidy The number of chromosomes that will be simulated per
 #'   individual.
 #' @param time The time at which the sample is taken.
-#' @return The feature, which can be added to a model using `+`.
-#' @keywords internal
+#' @keywords interna
+# @template feature
 feat_sample <- function(individuals, ploidy = 1, time = "0") {
   if (time != "0")
     stop("Samples at time different from 0 at not supported at the moment")

--- a/R/feature_selection.R
+++ b/R/feature_selection.R
@@ -13,7 +13,8 @@ selection_class <- R6Class("selection", inherit = feature_class,
   public = list(
     initialize = function(strength_AA, strength_Aa, strength_aa,
                           population, time, additive = FALSE,
-                          start, start_frequency, Ne, position, force_keep) {
+                          start, start_frequency, Ne, position, force_keep,
+                          locus_group) {
 
       assert_that(is.logical(additive) && length(additive) == 1)
       private$additive <- additive
@@ -41,6 +42,7 @@ selection_class <- R6Class("selection", inherit = feature_class,
 
       private$time <- private$add_parameter(time)
       private$set_population(population)
+      private$set_locus_group(locus_group)
     },
     get_strength_AA = function() private$strength_AA,
     get_strength_Aa = function() private$strength_Aa,
@@ -116,7 +118,7 @@ selection_class <- R6Class("selection", inherit = feature_class,
 #' @seealso For summary statistics that are sensitive for selection:
 #'   \code{\link{sumstat_tajimas_d}}, \code{\link{sumstat_ihh}},
 #'   \code{\link{sumstat_omega}}, \code{\link{sumstat_mcmf}}
-#' @family features
+#' @template  feature
 #' @examples
 #' # Positive additive selection in population 2:
 #' model <- coal_model(c(10, 13), 1, 10000) +
@@ -138,7 +140,8 @@ feat_selection <- function(strength_AA = 0,
                            start_frequency = 0.0005,
                            Ne = 10000,
                            position = 0.5,
-                           force_keep = TRUE) {
+                           force_keep = TRUE,
+                           locus_group = "all") {
 
   if (!is.null(strength_A)) {
     return(selection_class$new(strength_Aa = strength_A,
@@ -149,11 +152,13 @@ feat_selection <- function(strength_AA = 0,
                                start_frequency = start_frequency,
                                Ne = Ne,
                                position = position,
-                               force_keep = force_keep))
+                               force_keep = force_keep,
+                               locus_group = locus_group))
   }
 
   selection_class$new(strength_AA, strength_Aa, strength_aa, population, time,
-                      FALSE, start, start_frequency, Ne, position, force_keep)
+                      FALSE, start, start_frequency, Ne, position, force_keep,
+                      locus_group = locus_group)
 }
 
 

--- a/R/feature_size_change.R
+++ b/R/feature_size_change.R
@@ -26,7 +26,7 @@ size_change_class <- R6Class("size_change", inherit = feature_class,
 #' @return The feature, which can be added to a model using `+`.
 #' @export
 #' @seealso For continuous size changes over time: \code{\link{feat_growth}}.
-#' @family features
+#' @template feature
 #' @examples
 #' # A model with one smaller population:
 #' model <- coal_model(c(20, 5), 3) +
@@ -43,8 +43,10 @@ size_change_class <- R6Class("size_change", inherit = feature_class,
 #'   feat_mutation(20) +
 #'   sumstat_sfs()
 #' simulate(model)
-feat_size_change <- function(new_size, population = 1, time = "0") {
-  size_change_class$new(new_size, population, time)
+feat_size_change <- function(new_size, population = 1, time = "0",
+                             locus_group = "all") {
+  size_change_class$new(new_size, population, time,
+                        locus_group = locus_group)
 }
 
 #' @describeIn conv_to_ms_arg Feature conversion

--- a/R/feature_sumstats.R
+++ b/R/feature_sumstats.R
@@ -1,5 +1,6 @@
 segsites_feat_class <- R6Class("seg_sites_feat", inherit = feature_class,
   public = list(
+    initialize = function() super$initialize(locus_group = "all"),
     print = function() cat("Generating Seg. Sites\n")
   )
 )
@@ -29,6 +30,7 @@ conv_to_seqgen_arg.seg_sites_feat <- conv_to_ms_arg.seg_sites_feat #nolint
 
 trees_feat_class <- R6Class("trees_feat", inherit = feature_class,
   public = list(
+    initialize = function() super$initialize(locus_group = "all"),
     print = function() cat("Generating Trees\n")
   )
 )
@@ -55,6 +57,7 @@ conv_to_seqgen_arg.trees_feat <- function(feature, model) {
 
 files_feat_class <- R6Class("files_feat", inherit = feature_class,
   public = list(
+    initialize = function() super$initialize(locus_group = "all"),
     print = function() cat("Generating Files\n")
   )
 )

--- a/R/feature_unphased.R
+++ b/R/feature_unphased.R
@@ -1,9 +1,10 @@
 unphased_class <- R6Class("unphased", inherit = feature_class,
   private = list(ploidy = NA, samples_per_ind = NA),
   public = list(
-    initialize = function(samples_per_ind) {
+    initialize = function(samples_per_ind, locus_group) {
       assert_that(is.number(samples_per_ind))
       private$samples_per_ind <- samples_per_ind
+      private$set_locus_group(locus_group)
     },
     check = function(model) {
       if (self$get_samples_per_ind() > get_ploidy(model)) {
@@ -32,7 +33,7 @@ unphased_class <- R6Class("unphased", inherit = feature_class,
 #'   from the phased chromosomes for each individual.
 #' @return The feature, which can be added to a model using `+`.
 #' @export
-#' @family features
+#' @template feature
 #' @examples
 #' # Simulate unphased data in a diploid population
 #' model <- coal_model(10, 1, ploidy = 2) +
@@ -48,8 +49,8 @@ unphased_class <- R6Class("unphased", inherit = feature_class,
 #'   feat_unphased(1) +
 #'   sumstat_seg_sites()
 #' simulate(model)
-feat_unphased <- function(samples_per_ind) {
-  unphased_class$new(samples_per_ind)
+feat_unphased <- function(samples_per_ind, locus_group = "all") {
+  unphased_class$new(samples_per_ind, locus_group)
 }
 
 

--- a/R/model.R
+++ b/R/model.R
@@ -121,6 +121,12 @@ create_group_model <- function(model, group) {
     group_model <- model
     group_model$loci <- model$loci[group]
     group_model$id <- get_id()
+    feature_mask <- vapply(model$features, function(feat) {
+      if (feat$get_locus_group() == "all") return(TRUE)
+      if (any(feat$get_locus_group() == group)) return(TRUE)
+      FALSE
+    }, logical(1))
+    group_model$features <- model$features[feature_mask]
     cache(model, key, group_model)
   }
 

--- a/R/model_build.R
+++ b/R/model_build.R
@@ -63,8 +63,14 @@ add_to_model.feature <- function(feat, model, feat_name) {
   pop <- feat$get_population()
   if (!is.null(pop)) {
     if (pop != "all" && !all(pop %in% get_populations(model))) {
-      stop("Invalid population in ", feat_name)
+      stop("Invalid population in ", feat_name, call. = FALSE)
     }
+  }
+
+  # Check that the locus group is set correctly
+  locus_group <- feat$get_locus_group()
+  if (is.null(locus_group)) {
+    stop(feat_name, ": locus group has an invalid value", call. = FALSE)
   }
 
   # Execute the features checks

--- a/man-roxygen/feature.R
+++ b/man-roxygen/feature.R
@@ -1,0 +1,13 @@
+#' @seealso For creating a model: \code{\link{coal_model}}
+#' @family features
+#' @param locus_group The loci for which this features is used. Can either be
+#'   \code{"all"} (default), in which case the feature is used for simulating
+#'   all loci, or a numeric vector. In the latter case, the feature is only
+#'   used for the loci added in \code{locus_} commands  with the corresponding
+#'   index starting from 1 in order in which the commands where added to the
+#'   model. For example, if a model has
+#'   \code{locus_single(10) + locus_averaged(10, 11) + locus_single(12)} and
+#'   this argument is \code{c(2, 3)}, than the feature is used for all but
+#'   the first locus (that is locus 2 - 12).
+#' @return The feature, which can be added to a model created with
+#'   \code{\link{coal_model}} using \code{+}.

--- a/man/feat_growth.Rd
+++ b/man/feat_growth.Rd
@@ -4,7 +4,7 @@
 \alias{feat_growth}
 \title{Feature: Exponential population size growth/decline}
 \usage{
-feat_growth(rate, population = "all", time = "0")
+feat_growth(rate, population = "all", time = "0", locus_group = "all")
 }
 \arguments{
 \item{rate}{The growth rate. Can be a numeric or a \code{\link{parameter}}.
@@ -16,6 +16,20 @@ population size.}
 
 \item{time}{The time at which the growth rate is changed. Can also be
 a \code{\link{parameter}}.}
+
+\item{locus_group}{The loci for which this features is used. Can either be
+\code{"all"} (default), in which case the feature is used for simulating
+all loci, or a numeric vector. In the latter case, the feature is only
+used for the loci added in \code{locus_} commands  with the corresponding
+index starting from 1 in order in which the commands where added to the
+model. For example, if a model has
+\code{locus_single(10) + locus_averaged(10, 11) + locus_single(12)} and
+this argument is \code{c(2, 3)}, than the feature is used for all but
+the first locus (that is locus 2 - 12).}
+}
+\value{
+The feature, which can be added to a model created with
+  \code{\link{coal_model}} using \code{+}.
 }
 \description{
 This feature changes the growth factor of a population at given
@@ -42,6 +56,8 @@ simulate(model)
 \seealso{
 For instantaneous population size
          changes: \code{\link{feat_size_change}}
+
+For creating a model: \code{\link{coal_model}}
 
 Other features: \code{\link{feat_ignore_singletons}},
   \code{\link{feat_migration}},

--- a/man/feat_ignore_singletons.Rd
+++ b/man/feat_ignore_singletons.Rd
@@ -4,10 +4,22 @@
 \alias{feat_ignore_singletons}
 \title{Feature: Ignore Singletons}
 \usage{
-feat_ignore_singletons()
+feat_ignore_singletons(locus_group = "all")
+}
+\arguments{
+\item{locus_group}{The loci for which this features is used. Can either be
+\code{"all"} (default), in which case the feature is used for simulating
+all loci, or a numeric vector. In the latter case, the feature is only
+used for the loci added in \code{locus_} commands  with the corresponding
+index starting from 1 in order in which the commands where added to the
+model. For example, if a model has
+\code{locus_single(10) + locus_averaged(10, 11) + locus_single(12)} and
+this argument is \code{c(2, 3)}, than the feature is used for all but
+the first locus (that is locus 2 - 12).}
 }
 \value{
-The feature, which can be added to a model using `+`.
+The feature, which can be added to a model created with
+  \code{\link{coal_model}} using \code{+}.
 }
 \description{
 Mutations that are observed in just one haplotype ('singletons') are often
@@ -31,6 +43,8 @@ model <- coal_model(2, 1) +
 simulate(model)$n_mut
 }
 \seealso{
+For creating a model: \code{\link{coal_model}}
+
 Other features: \code{\link{feat_growth}},
   \code{\link{feat_migration}},
   \code{\link{feat_mutation}}, \code{\link{feat_outgroup}},

--- a/man/feat_migration.Rd
+++ b/man/feat_migration.Rd
@@ -5,7 +5,7 @@
 \title{Feature: Migration/Gene Flow}
 \usage{
 feat_migration(rate, pop_from = NULL, pop_to = NULL, symmetric = FALSE,
-  time = "0")
+  time = "0", locus_group = "all")
 }
 \arguments{
 \item{rate}{The migration rate. Can be a numeric or a
@@ -23,6 +23,20 @@ from \code{pop_from} each generation (in forward time).}
 \item{time}{The time point at which the migration with the migration
 rate is set. The rate applies to the time past warts
 of the time point, until it is changed again.}
+
+\item{locus_group}{The loci for which this features is used. Can either be
+\code{"all"} (default), in which case the feature is used for simulating
+all loci, or a numeric vector. In the latter case, the feature is only
+used for the loci added in \code{locus_} commands  with the corresponding
+index starting from 1 in order in which the commands where added to the
+model. For example, if a model has
+\code{locus_single(10) + locus_averaged(10, 11) + locus_single(12)} and
+this argument is \code{c(2, 3)}, than the feature is used for all but
+the first locus (that is locus 2 - 12).}
+}
+\value{
+The feature, which can be added to a model created with
+  \code{\link{coal_model}} using \code{+}.
 }
 \description{
 This feature changes the migration rates at a given time point.
@@ -54,6 +68,8 @@ model <- coal_model(c(3, 4, 5), 2) +
 simulate(model)
 }
 \seealso{
+For creating a model: \code{\link{coal_model}}
+
 Other features: \code{\link{feat_growth}},
   \code{\link{feat_ignore_singletons}},
   \code{\link{feat_mutation}}, \code{\link{feat_outgroup}},

--- a/man/feat_mutation.Rd
+++ b/man/feat_mutation.Rd
@@ -5,7 +5,7 @@
 \title{Feature: Mutation}
 \usage{
 feat_mutation(rate, model = "IFS", base_frequencies = NA, tstv_ratio = NA,
-  gtr_rates = NA, fixed_number = FALSE)
+  gtr_rates = NA, fixed_number = FALSE, locus_group = "all")
 }
 \arguments{
 \item{rate}{The mutation rate. Can be a numeric or a \code{\link{parameter}}.
@@ -30,9 +30,22 @@ Order: A<->C, A<->G, A<->T, C<->G, C<->T, G<->T.}
 \item{fixed_number}{If set to \code{TRUE}, the number of mutations on each
 locus will always be exactly equal to the rate, rather than happening with
 a rate along the ancestral tree.}
+
+\item{locus_group}{The loci for which this features is used. Can either be
+\code{"all"} (default), in which case the feature is used for simulating
+all loci, or a numeric vector. In the latter case, the feature is only
+used for the loci added in \code{locus_} commands  with the corresponding
+index starting from 1 in order in which the commands where added to the
+model. For example, if a model has
+\code{locus_single(10) + locus_averaged(10, 11) + locus_single(12)} and
+this argument is \code{c(2, 3)}, than the feature is used for all but
+the first locus (that is locus 2 - 12).}
 }
 \value{
 The feature, which can be added to a model using `+`.
+
+The feature, which can be added to a model created with
+  \code{\link{coal_model}} using \code{+}.
 }
 \description{
 This feature adds mutations to a model. Mutations occur in the genomes
@@ -98,6 +111,8 @@ For using rates that variate between the loci in a model:
   \code{\link{par_variation}}, \code{\link{par_zero_inflation}}
 
 For adding recombination: \code{\link{feat_recombination}}.
+
+For creating a model: \code{\link{coal_model}}
 
 Other features: \code{\link{feat_growth}},
   \code{\link{feat_ignore_singletons}},

--- a/man/feat_outgroup.Rd
+++ b/man/feat_outgroup.Rd
@@ -4,10 +4,24 @@
 \alias{feat_outgroup}
 \title{Feature: Outgroup}
 \usage{
-feat_outgroup(population)
+feat_outgroup(population, locus_group = "all")
 }
 \arguments{
 \item{population}{The population that is marked as outgroup.}
+
+\item{locus_group}{The loci for which this features is used. Can either be
+\code{"all"} (default), in which case the feature is used for simulating
+all loci, or a numeric vector. In the latter case, the feature is only
+used for the loci added in \code{locus_} commands  with the corresponding
+index starting from 1 in order in which the commands where added to the
+model. For example, if a model has
+\code{locus_single(10) + locus_averaged(10, 11) + locus_single(12)} and
+this argument is \code{c(2, 3)}, than the feature is used for all but
+the first locus (that is locus 2 - 12).}
+}
+\value{
+The feature, which can be added to a model created with
+  \code{\link{coal_model}} using \code{+}.
 }
 \description{
 This feature declares an existing population as outgroup. Outgroups are used
@@ -25,6 +39,8 @@ model <- coal_model(c(4, 6, 1), 2, 10) +
    feat_mutation(5, model = "GTR", gtr_rates = 1:6)
 }
 \seealso{
+For creating a model: \code{\link{coal_model}}
+
 Other features: \code{\link{feat_growth}},
   \code{\link{feat_ignore_singletons}},
   \code{\link{feat_migration}},

--- a/man/feat_pop_merge.Rd
+++ b/man/feat_pop_merge.Rd
@@ -4,7 +4,7 @@
 \alias{feat_pop_merge}
 \title{Feature: Population Merge}
 \usage{
-feat_pop_merge(time, pop_source, pop_target)
+feat_pop_merge(time, pop_source, pop_target, locus_group = "all")
 }
 \arguments{
 \item{time}{The time at which the merge occurs.}
@@ -14,6 +14,20 @@ This is the newly created population in the speciation event.}
 
 \item{pop_target}{The population to which the lines are moved. This is
 the population in which the speciation event occurs.}
+
+\item{locus_group}{The loci for which this features is used. Can either be
+\code{"all"} (default), in which case the feature is used for simulating
+all loci, or a numeric vector. In the latter case, the feature is only
+used for the loci added in \code{locus_} commands  with the corresponding
+index starting from 1 in order in which the commands where added to the
+model. For example, if a model has
+\code{locus_single(10) + locus_averaged(10, 11) + locus_single(12)} and
+this argument is \code{c(2, 3)}, than the feature is used for all but
+the first locus (that is locus 2 - 12).}
+}
+\value{
+The feature, which can be added to a model created with
+  \code{\link{coal_model}} using \code{+}.
 }
 \description{
 Backwards in time, this feature merges one population into another.
@@ -40,6 +54,8 @@ model_iwm <- model +
 simulate(model_iwm)
 }
 \seealso{
+For creating a model: \code{\link{coal_model}}
+
 Other features: \code{\link{feat_growth}},
   \code{\link{feat_ignore_singletons}},
   \code{\link{feat_migration}},

--- a/man/feat_recombination.Rd
+++ b/man/feat_recombination.Rd
@@ -4,16 +4,29 @@
 \alias{feat_recombination}
 \title{Feature: Recombination}
 \usage{
-feat_recombination(rate)
+feat_recombination(rate, locus_group = "all")
 }
 \arguments{
 \item{rate}{The recombination rate. Can be a numeric or a
 \code{\link{parameter}}. The rate is equal to
 \eqn{4*N0*r}, where \eqn{r} is the probability that a
 recombination event within the locus occurs in one generation.}
+
+\item{locus_group}{The loci for which this features is used. Can either be
+\code{"all"} (default), in which case the feature is used for simulating
+all loci, or a numeric vector. In the latter case, the feature is only
+used for the loci added in \code{locus_} commands  with the corresponding
+index starting from 1 in order in which the commands where added to the
+model. For example, if a model has
+\code{locus_single(10) + locus_averaged(10, 11) + locus_single(12)} and
+this argument is \code{c(2, 3)}, than the feature is used for all but
+the first locus (that is locus 2 - 12).}
 }
 \value{
 The feature, which can be added to a model using `+`.
+
+The feature, which can be added to a model created with
+  \code{\link{coal_model}} using \code{+}.
 }
 \description{
 This feature adds intra-locus recombination to a model.  The rate is per locus
@@ -32,6 +45,8 @@ model <- coal_model(10, 2, 1500) +
 simulate(model)
 }
 \seealso{
+For creating a model: \code{\link{coal_model}}
+
 For adding recombination: \code{\link{feat_mutation}}.
 
 Other features: \code{\link{feat_growth}},

--- a/man/feat_sample.Rd
+++ b/man/feat_sample.Rd
@@ -15,11 +15,8 @@ individual.}
 
 \item{time}{The time at which the sample is taken.}
 }
-\value{
-The feature, which can be added to a model using `+`.
-}
 \description{
 Creates a feature that represents the sampling from one population
 }
-\keyword{internal}
+\keyword{interna}
 

--- a/man/feat_selection.Rd
+++ b/man/feat_selection.Rd
@@ -7,7 +7,7 @@
 feat_selection(strength_AA = 0, strength_Aa = 0, strength_aa = 0,
   strength_A = NULL, population = "all", time, start = TRUE,
   start_frequency = 5e-04, Ne = 10000, position = 0.5,
-  force_keep = TRUE)
+  force_keep = TRUE, locus_group = "all")
 }
 \arguments{
 \item{strength_AA}{The selection strength for the selected homozygote.
@@ -58,6 +58,20 @@ while smaller values are to the left of it and larger ones to the right.}
 
 \item{force_keep}{Whether to restart simulations in which the selected goes to
 extinction or not.}
+
+\item{locus_group}{The loci for which this features is used. Can either be
+\code{"all"} (default), in which case the feature is used for simulating
+all loci, or a numeric vector. In the latter case, the feature is only
+used for the loci added in \code{locus_} commands  with the corresponding
+index starting from 1 in order in which the commands where added to the
+model. For example, if a model has
+\code{locus_single(10) + locus_averaged(10, 11) + locus_single(12)} and
+this argument is \code{c(2, 3)}, than the feature is used for all but
+the first locus (that is locus 2 - 12).}
+}
+\value{
+The feature, which can be added to a model created with
+  \code{\link{coal_model}} using \code{+}.
 }
 \description{
 This feature adds selection to a model. Only one site per locus can be under
@@ -83,6 +97,8 @@ For using rates that variate between the loci in a model:
 For summary statistics that are sensitive for selection:
   \code{\link{sumstat_tajimas_d}}, \code{\link{sumstat_ihh}},
   \code{\link{sumstat_omega}}, \code{\link{sumstat_mcmf}}
+
+For creating a model: \code{\link{coal_model}}
 
 Other features: \code{\link{feat_growth}},
   \code{\link{feat_ignore_singletons}},

--- a/man/feat_size_change.Rd
+++ b/man/feat_size_change.Rd
@@ -4,7 +4,8 @@
 \alias{feat_size_change}
 \title{Feature: Instantaneous Size Change}
 \usage{
-feat_size_change(new_size, population = 1, time = "0")
+feat_size_change(new_size, population = 1, time = "0",
+  locus_group = "all")
 }
 \arguments{
 \item{new_size}{A \code{\link{parameter}} giving the new size of the
@@ -15,9 +16,22 @@ Can also be set to "all". Then the size changes applies to all
 populations.}
 
 \item{time}{The time at which the population's size is changed.}
+
+\item{locus_group}{The loci for which this features is used. Can either be
+\code{"all"} (default), in which case the feature is used for simulating
+all loci, or a numeric vector. In the latter case, the feature is only
+used for the loci added in \code{locus_} commands  with the corresponding
+index starting from 1 in order in which the commands where added to the
+model. For example, if a model has
+\code{locus_single(10) + locus_averaged(10, 11) + locus_single(12)} and
+this argument is \code{c(2, 3)}, than the feature is used for all but
+the first locus (that is locus 2 - 12).}
 }
 \value{
 The feature, which can be added to a model using `+`.
+
+The feature, which can be added to a model created with
+  \code{\link{coal_model}} using \code{+}.
 }
 \description{
 This feature changes the effective population size of one
@@ -45,6 +59,8 @@ simulate(model)
 }
 \seealso{
 For continuous size changes over time: \code{\link{feat_growth}}.
+
+For creating a model: \code{\link{coal_model}}
 
 Other features: \code{\link{feat_growth}},
   \code{\link{feat_ignore_singletons}},

--- a/man/feat_unphased.Rd
+++ b/man/feat_unphased.Rd
@@ -4,14 +4,27 @@
 \alias{feat_unphased}
 \title{Feature: Unphased Sequences}
 \usage{
-feat_unphased(samples_per_ind)
+feat_unphased(samples_per_ind, locus_group = "all")
 }
 \arguments{
 \item{samples_per_ind}{The number of pseudo-chromosomes that are created
 from the phased chromosomes for each individual.}
+
+\item{locus_group}{The loci for which this features is used. Can either be
+\code{"all"} (default), in which case the feature is used for simulating
+all loci, or a numeric vector. In the latter case, the feature is only
+used for the loci added in \code{locus_} commands  with the corresponding
+index starting from 1 in order in which the commands where added to the
+model. For example, if a model has
+\code{locus_single(10) + locus_averaged(10, 11) + locus_single(12)} and
+this argument is \code{c(2, 3)}, than the feature is used for all but
+the first locus (that is locus 2 - 12).}
 }
 \value{
 The feature, which can be added to a model using `+`.
+
+The feature, which can be added to a model created with
+  \code{\link{coal_model}} using \code{+}.
 }
 \description{
 This simulates unphased data by randomly mixing the sites within one
@@ -38,6 +51,8 @@ model <- coal_model(10, 1, ploidy = 2) +
 simulate(model)
 }
 \seealso{
+For creating a model: \code{\link{coal_model}}
+
 Other features: \code{\link{feat_growth}},
   \code{\link{feat_ignore_singletons}},
   \code{\link{feat_migration}},

--- a/tests/testthat/test-feature-class.R
+++ b/tests/testthat/test-feature-class.R
@@ -45,4 +45,3 @@ test_that("setting a locus group works", {
 
   expect_error(feature_class$new("abc", locus_group = "wrong value"))
 })
-

--- a/tests/testthat/test-feature-class.R
+++ b/tests/testthat/test-feature-class.R
@@ -34,3 +34,15 @@ test_that("print parameter works", {
   expect_equal(print_par("par(5)"), "`5`")
   expect_equal(print_par("par(2 * theta)"), "`2 * theta`")
 })
+
+
+test_that("setting a locus group works", {
+  feat <- feature_class$new("abc", locus_group = "all")
+  expect_equal(feat$get_locus_group(), "all")
+
+  feat <- feature_class$new("abc", locus_group = 1:3)
+  expect_equal(feat$get_locus_group(), 1:3)
+
+  expect_error(feature_class$new("abc", locus_group = "wrong value"))
+})
+

--- a/tests/testthat/test-model-class.R
+++ b/tests/testthat/test-model-class.R
@@ -34,9 +34,9 @@ test_that("adding parameters works", {
 
 test_that("adding features works", {
   expect_equal(length(get_features(coal_model(5))), 1)
-  model <- coal_model(5) + feature_class$new(1, 1, 5)
+  model <- coal_model(5) + feature_class$new(1, 1, 5, locus_group = "all")
   expect_equal(length(get_features(model)), 2)
-  model <- model + feature_class$new(2, 1, 3)
+  model <- model + feature_class$new(2, 1, 3, locus_group = "all")
   expect_equal(length(get_features(model)), 3)
 })
 

--- a/tests/testthat/test-model-class.R
+++ b/tests/testthat/test-model-class.R
@@ -335,3 +335,14 @@ test_that("create_group_models creates group models", {
   expect_equal(create_group_model(model, 2)$loci, list(locus_averaged(2, 5)))
   expect_equal(create_group_model(model, 3)$loci, list(locus_single(7)))
 })
+
+
+test_that("group models respect feature restrictions", {
+  model <- coal_model(10, 5) +
+    locus_single(15) +
+    feat_mutation(5, locus_group = 2)
+  expect_equal(create_group_model(model, 1)$features,
+               coal_model(10, 5)$features)
+  expect_equal(create_group_model(model, 2)$features,
+               model$features)
+})


### PR DESCRIPTION
Introduces the optional `locus_group` argument for features. This argument allow to use this feature only for a subset of loci in the model. Amoung other things this addresses #161 : 

```R
model <- coal_model(4) + 
   locus_averaged(10, 100) + 
   locus_averaged(10, 100) +
   feat_mutation(5.0, locus_group = 1) +
   feat_mutation(7.5, locus_group = 2) +
   sumstat_seg_sites()
simulate(model)
```

Here, the first 10 loci use a mutation rate of `5.0` and the second 10 use a rate of `7.5`.